### PR TITLE
Feature/argocd bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ We can then deploy a specific pattern with the following:
 cdk deploy multi-team-blueprint
 ```
 
+# Deploying Blueprints with External Dependency on AWS Resources
+
+There are cases when the blueprints defined in the SSP Patterns have dependencies on existing AWS Resources such as Secrets defined in the account/region.
+For such cases, you may see errors if such resources are not defined. 
+
+For `MultiRegionConstruct` the pattern relies on the following secrets defined:
+
+1. `github-ssh-key` - must contain GitHub SSH private key in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
+2. `argo-admin-secret` - must contain ArgoCD admin password in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
+
+For more information on defining secrets for ArgoCD, please refer to [SSP Documentation](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#secrets-support) as well as [known issues](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#known-issues).
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/lib/multi-region-construct/index.ts
+++ b/lib/multi-region-construct/index.ts
@@ -42,7 +42,7 @@ export default class MultiRegionConstruct extends cdk.Construct {
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/test',
-                credentialsSecretName: 'github-ssh-test',
+                credentialsSecretName: 'github-ssp-ssh',
                 credentialsType: 'SSH'
             }
         });
@@ -50,7 +50,7 @@ export default class MultiRegionConstruct extends cdk.Construct {
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/prod',
-                credentialsSecretName: 'github-ssh-test',
+                credentialsSecretName: 'github-ssp-ssh',
                 credentialsType: 'SSH'
             }
         });

--- a/lib/multi-region-construct/index.ts
+++ b/lib/multi-region-construct/index.ts
@@ -46,20 +46,22 @@ export default class MultiRegionConstruct extends cdk.Construct {
                 path: 'envs/dev'
             }
         });
+
         const testBootstrapArgo = new ArgoCDAddOn({
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/test',
-                credentialsSecretName: 'github-ssh-test',
+                credentialsSecretName: 'github-ssh-key',
                 credentialsType: 'SSH'
             },
         
         });
+
         const prodBootstrapArgo = new ArgoCDAddOn({
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/prod',
-                credentialsSecretName: 'github-ssh-test',
+                credentialsSecretName: 'github-ssh-key',
                 credentialsType: 'SSH'
             },
             adminPasswordSecretName: 'argo-admin-secret',

--- a/lib/multi-region-construct/index.ts
+++ b/lib/multi-region-construct/index.ts
@@ -7,6 +7,14 @@ import { ArgoCDAddOn } from '@shapirov/cdk-eks-blueprint';
 // Team implementations
 import * as team from '../teams'
 
+
+/**
+ * This pattern demonstrates how to roll out a platform across multiple regions and multiple stages.
+ * Each region represents a stage in the development process, i.e. dev, test, prod. 
+ * To use this pattern as is you need to create the following secrets in us-east-1 and replicate them to us-east-2 and us-west-2:
+ * - github-ssh-test - containing SSH key for github authentication (plaintext in AWS Secrets manager)
+ * - argo-admin-secret - containing the initial admin secret for ArgoCD (e.g. CLI and UI access)
+ */
 export default class MultiRegionConstruct extends cdk.Construct {
     constructor(scope: cdk.Construct, id: string) {
         super(scope, id);
@@ -42,17 +50,19 @@ export default class MultiRegionConstruct extends cdk.Construct {
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/test',
-                credentialsSecretName: 'github-ssp-ssh',
+                credentialsSecretName: 'github-ssh-test',
                 credentialsType: 'SSH'
-            }
+            },
+        
         });
         const prodBootstrapArgo = new ArgoCDAddOn({
             bootstrapRepo: {
                 repoUrl: 'git@github.com:aws-samples/ssp-eks-workloads.git',
                 path: 'envs/prod',
-                credentialsSecretName: 'github-ssp-ssh',
+                credentialsSecretName: 'github-ssh-test',
                 credentialsType: 'SSH'
-            }
+            },
+            adminPasswordSecretName: 'argo-admin-secret',
         });
 
         const east1 = 'us-east-1';

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.104.0",
+    "@aws-cdk/assert": "1.113.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
-    "aws-cdk": "1.104.0",
+    "aws-cdk": "1.113.0",
     "copyfiles": "^2.4.1",
     "eslint": "^7.26.0",
     "jest": "^26.4.2",
@@ -28,8 +28,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.104.0",
-    "@shapirov/cdk-eks-blueprint": "^0.10.0",
+    "@aws-cdk/core": "1.113.0",
+    "@shapirov/cdk-eks-blueprint": "file:../quickstart-ssp-amazon-eks/shapirov-cdk-eks-blueprint-0.11.1.tgz",
     "source-map-support": "^0.5.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.113.0",
-    "@shapirov/cdk-eks-blueprint": "file:../quickstart-ssp-amazon-eks/shapirov-cdk-eks-blueprint-0.11.1.tgz",
+    "@shapirov/cdk-eks-blueprint": "^0.11.1",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* 32 (in the quick start project)

*Description of changes:*
Modified multi-region pipeline to bootstrap ArgoCD workloads and set initial admin secret from secret manager. 

Verification instructions:

1. Update the quick start from the https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/pull/148. This will increment the package version to 0.11.1
2. Run `make build` followed by `npm pack`.
3. Create the following secrets:
3.1 `github-ssh-test`, plaintext, containing SSH Key for GitHub (generate new one). Secret should be in us-east-1, replicating to us-east-2 and us-west-2.
3.2 `argo-admin-secret`, plaintext, containing desired password for Argo admin UI. Also in us-east-1, replicated to us-east-2, us-west-2.
4. In the ssp-patterns repository  checkout the current PR. 
5. Run `npm i ../quickstart-ssp-amazon-eks/shapirov-cdk-eks-blueprint-0.11.1.tgz` (assuming roots of quick start and patterns repos are in the same dir). 
6. Run `make build`
7. Run `cdk deploy multi-region-us-west-2`. 
8. Once cluster up and running verify the following:
8.1. Pods in argocd namespace are up and running
8.2 The application in team-burnham (guest book) is automatically bootstrapped.
8.3 port forward for argocd-server service. Navigate to localhost:8080 and login using admin/<your password from 3.2>.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
