### PR TITLE
Add a "starter" pattern

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -6,6 +6,13 @@ const app = new cdk.App();
 import NginxIngressConstruct from '../lib/nginx-ingress-construct';
 new NginxIngressConstruct(app, 'nginx');
 
+//-------------------------------------------
+// Starter Cluster with barebone infrastructure.
+//-------------------------------------------
+
+import StarterConstruct from '../lib/starter-construct';
+new StarterConstruct(app, 'starter');
+
 
 //-------------------------------------------
 // Single Cluster with multiple teams.

--- a/lib/multi-region-construct/index.ts
+++ b/lib/multi-region-construct/index.ts
@@ -37,7 +37,8 @@ export default class MultiRegionConstruct {
         
         const blueprint = ssp.EksBlueprint.builder()
             .account(process.env.CDK_DEFAULT_ACCOUNT!)
-            .addOns(new ssp.NginxAddOn,
+            .addOns(new ssp.AwsLoadBalancerControllerAddOn,
+                new ssp.NginxAddOn,
                 new ssp.CalicoAddOn,
                 new ssp.MetricsServerAddOn,
                 new ssp.ClusterAutoScalerAddOn,

--- a/lib/starter-construct/index.ts
+++ b/lib/starter-construct/index.ts
@@ -8,12 +8,12 @@ export default class StarterConstruct extends cdk.Construct {
     constructor(scope: cdk.Construct, id: string) {
         super(scope, id);
 
-        // To do - Onboard teams
+        // Onboard teams as necessary - import lib/teams
         const teams: Array<ssp.Team> = [
 
         ];
 
-        // AddOns for the cluster.
+        // Include more addons as necessary
         const addOns: Array<ssp.ClusterAddOn> = [
             new ssp.ArgoCDAddOn
         ];

--- a/lib/starter-construct/index.ts
+++ b/lib/starter-construct/index.ts
@@ -1,0 +1,30 @@
+import * as cdk from '@aws-cdk/core';
+
+// SSP Lib
+import * as ssp from '@aws-quickstart/ssp-amazon-eks'
+
+
+export default class StarterConstruct extends cdk.Construct {
+    constructor(scope: cdk.Construct, id: string) {
+        super(scope, id);
+
+        // To do - Onboard teams
+        const teams: Array<ssp.Team> = [
+
+        ];
+
+        // AddOns for the cluster.
+        const addOns: Array<ssp.ClusterAddOn> = [
+            new ssp.ArgoCDAddOn
+        ];
+
+        const stackID = `${id}-blueprint`
+        new ssp.EksBlueprint(scope, { id: stackID, addOns, teams }, {
+            env: {
+                region: 'us-east-2',
+            },
+        });
+    }
+}
+
+


### PR DESCRIPTION
*Issue #, if available:* #7 

*Description of changes:*
- Adding a "starter" pattern: Barebone blueprint allow you to add teams, addons and other functionalities as you go. 
- Added the addons in the right order for multi region blueprint to work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
