### PR TITLE
Add Kubecost construct example

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -71,3 +71,6 @@ new CustomClusterConstruct(app, 'custom-cluster');
 
 import ScratchpadConstruct from '../lib/scratchpad';
 new ScratchpadConstruct(app, 'scratchpad');
+
+import KubecostConstruct from '../lib/kubecost-construct';
+new KubecostConstruct(app, 'kubecost')

--- a/lib/kubecost-construct/index.ts
+++ b/lib/kubecost-construct/index.ts
@@ -12,7 +12,7 @@ export default class KubecostConstruct extends cdk.Construct {
             new KubecostAddOn()
         ];
 
-        const stackID = `${id}-blueprint`
+        const stackID = `${id}-blueprint`;
 
         new ssp.EksBlueprint(scope, { id: stackID, addOns}, {
             env: {

--- a/lib/kubecost-construct/index.ts
+++ b/lib/kubecost-construct/index.ts
@@ -1,7 +1,7 @@
 import * as cdk from '@aws-cdk/core';
 import * as ssp from '@aws-quickstart/ssp-amazon-eks'
 
-import { KubecostAddOn } from '@kubecost/kubecost-ssp-addon';
+import { KubecostAddOn, KubecostAddOnProps } from '@kubecost/kubecost-ssp-addon';
 
 export default class KubecostConstruct extends cdk.Construct {
     constructor(scope: cdk.Construct, id: string) {

--- a/lib/kubecost-construct/index.ts
+++ b/lib/kubecost-construct/index.ts
@@ -1,0 +1,24 @@
+import * as cdk from '@aws-cdk/core';
+import * as ssp from '@aws-quickstart/ssp-amazon-eks'
+
+import { KubecostAddOn } from '@kubecost/kubecost-ssp-addon';
+
+export default class KubecostConstruct extends cdk.Construct {
+    constructor(scope: cdk.Construct, id: string) {
+        super(scope, id);
+
+        // AddOns for the cluster
+        const addOns: Array<ssp.ClusterAddOn> = [
+            new KubecostAddOn()
+        ];
+
+        const stackID = `${id}-blueprint`
+
+        new ssp.EksBlueprint(scope, { id: stackID, addOns}, {
+            env: {
+                account : process.env.CDK_DEFAULT_ACCOUNT!,
+                region: process.env.CDK_DEFAULT_REGION
+            },
+        });
+    }
+}

--- a/lib/kubecost-construct/index.ts
+++ b/lib/kubecost-construct/index.ts
@@ -1,24 +1,18 @@
 import * as cdk from '@aws-cdk/core';
-import * as ssp from '@aws-quickstart/ssp-amazon-eks'
+import { EksBlueprint } from '@aws-quickstart/ssp-amazon-eks';
+import { KubecostAddOn } from '@kubecost/kubecost-ssp-addon';
 
-import { KubecostAddOn, KubecostAddOnProps } from '@kubecost/kubecost-ssp-addon';
 
 export default class KubecostConstruct extends cdk.Construct {
     constructor(scope: cdk.Construct, id: string) {
         super(scope, id);
-
         // AddOns for the cluster
-        const addOns: Array<ssp.ClusterAddOn> = [
-            new KubecostAddOn()
-        ];
+        const stackId = `${id}-blueprint`;
 
-        const stackID = `${id}-blueprint`;
-
-        new ssp.EksBlueprint(scope, { id: stackID, addOns}, {
-            env: {
-                account : process.env.CDK_DEFAULT_ACCOUNT!,
-                region: process.env.CDK_DEFAULT_REGION
-            },
-        });
+        EksBlueprint.builder()
+            .account(process.env.CDK_DEFAULT_ACCOUNT!)
+            .region(process.env.CDK_DEFAULT_REGION)
+            .addOns(new KubecostAddOn())
+            .build(scope, stackId);
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-quickstart/ssp-amazon-eks": "^0.12.3",
-    "@kubecost/kubecost-ssp-addon": "^1.0.5",
+    "@kubecost/kubecost-ssp-addon": "^1.0.8",
     "source-map-support": "^0.5.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-quickstart/ssp-amazon-eks": "^0.12.3",
-    "@kubecost/kubecost-ssp-addon": "^1.0.2",
+    "@kubecost/kubecost-ssp-addon": "^1.0.5",
     "source-map-support": "^0.5.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@aws-quickstart/ssp-amazon-eks": "^0.12.3",
+    "@kubecost/kubecost-ssp-addon": "^1.0.2",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
*Description of changes:*

Add a [Kubecost AddOn](https://github.com/kubecost/kubecost-ssp-addon) usage example to `lib/`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
