### PR TITLE
feat: Adding Keptn pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For `MultiRegionConstruct` the pattern relies on the following secrets defined:
 
 1. `github-ssh-key` - must contain GitHub SSH private key in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
 2. `argo-admin-secret` - must contain ArgoCD admin password in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
-3. `keptn-secrets` - must contain API_TOKEN and BRIDGE_PASSWORD password in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
+3. `keptn-secrets` - must contain API_TOKEN and BRIDGE_PASSWORD password in Plain Text. The secret is expected to be defined in `us-east-1` region.
 
 For more information on defining secrets for ArgoCD, please refer to [SSP Documentation](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#secrets-support) as well as [known issues](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#known-issues).
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For `MultiRegionConstruct` the pattern relies on the following secrets defined:
 
 1. `github-ssh-key` - must contain GitHub SSH private key in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
 2. `argo-admin-secret` - must contain ArgoCD admin password in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
+3. `keptn-secrets` - must contain API_TOKEN and BRIDGE_PASSWORD password in Plain Text. The secret is expected to be defined in `us-east-1` and replicated to `us-east-1` and `us-west-2` regions.
 
 For more information on defining secrets for ArgoCD, please refer to [SSP Documentation](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#secrets-support) as well as [known issues](https://github.com/aws-quickstart/quickstart-ssp-amazon-eks/blob/main/docs/addons/argo-cd.md#known-issues).
 

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -76,3 +76,6 @@ new ScratchpadConstruct(app, 'scratchpad');
 
 import KubecostConstruct from '../lib/kubecost-construct';
 new KubecostConstruct(app, 'kubecost')
+
+import KeptnControlPlaneConstruct from '../lib/keptn-construct';
+new KeptnControlPlaneConstruct(app, 'keptn')

--- a/lib/keptn-construct/index.ts
+++ b/lib/keptn-construct/index.ts
@@ -1,0 +1,22 @@
+import * as cdk from '@aws-cdk/core';
+import { EksBlueprint } from '@aws-quickstart/ssp-amazon-eks';
+import { KeptnControlPlaneAddOn } from '@keptn/keptn-cp-ssp-addon'
+
+export default class KeptnControlPlaneConstruct extends cdk.Construct {
+
+    constructor(scope: cdk.Construct, id: string) {
+        super(scope, id);
+        // AddOns for the cluster
+        const stackId = `${id}-blueprint`;
+
+        const KeptnControlPlane = new KeptnControlPlaneAddOn({
+            ssmSecretName: 'keptn-secrets'
+        })
+
+        EksBlueprint.builder()
+            .account(process.env.CDK_DEFAULT_ACCOUNT!)
+            .region(process.env.CDK_DEFAULT_REGION)
+            .addOns(KeptnControlPlane)
+            .build(scope, stackId);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@aws-quickstart/ssp-amazon-eks": "0.12.4",
     "@kubecost/kubecost-ssp-addon": "^1.0.8",
-    "@keptn/keptn-cp-ssp-addon": "^0.2.0",
+    "@keptn/keptn-cp-ssp-addon": "^0.3.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aws-quickstart/ssp-amazon-eks": "0.12.4",
     "@kubecost/kubecost-ssp-addon": "^1.0.8",
+    "@keptn/keptn-cp-ssp-addon": "^0.2.0",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
Signed-off-by: Christian Heckelmann <christian.heckelmann@dynatrace.com>

*Description of changes:*

Adding Keptn Control Plane Pattern requested within this PR: https://github.com/aws-samples/ssp-eks-patterns/compare/main...heckelmann:keptn-pattern?expand=1

This Pattern does not include the Keptn Execution Plane AddOn (https://github.com/keptn-sandbox/keptn-ssp-addons), as this will only work with an existing Keptn Control Plane.

A Secrets Manager Secret is expected as described within the README.md file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
